### PR TITLE
[fix commands] I fixed an issue of the command destroy

### DIFF
--- a/console.py
+++ b/console.py
@@ -88,6 +88,8 @@ class HBNBCommand(cmd.Cmd):
                         c = False
                 if c == False:
                     print("** no instance found **")
+            else:
+                print("** class doesn't exist **")
         elif len(line) == 1:
             if line[0] in self.dict_classes:
                 print("** instance id missing **")


### PR DESCRIPTION
I fixed a bug with the command "destroy" when i write a type class and id but the class does'nt exist